### PR TITLE
Allow Setting SSID with Spaces via Console

### DIFF
--- a/src/NetworkModule.cpp
+++ b/src/NetworkModule.cpp
@@ -555,23 +555,29 @@ bool NetworkModule::processCommand(const std::string cmd, bool debugKo)
     }
 
     #ifdef KNX_IP_WIFI
-    else if (cmd.compare(0, 5, "wifi ") == 0 && cmd.length() > 8)
+    else if (cmd.compare(0, 4, "wifi") == 0 && cmd.length() > 6)
     {
+        // Command: "wifi<SEP><ssid><SEP><psk>" with <SEP>=" " compatible to previous command
+        char delimiter = cmd[4];
+        std::string ssid_psk = cmd.substr(5);
+        size_t pos = ssid_psk.find(delimiter);
 
-        std::istringstream iss(cmd);
-        std::string token;
-        std::string ssid;
-        std::string psk;
+        if (pos != std::string::npos)
+        {
+            std::string ssid = ssid_psk.substr(0, pos);
+            std::string psk = ssid_psk.substr(pos + 1);
 
-        iss >> token; // wifi am anfang
-        iss >> ssid;  // ssid
-        iss >> psk;   // psk
+            logInfoP("WLAN SSID: %s", ssid.c_str());
 
-        logInfoP("WLAN SSID: %s", ssid.c_str());
+            saveWifiSettings(ssid.c_str(), psk.c_str());
 
-        saveWifiSettings(ssid.c_str(), psk.c_str());
-
-        return true;
+            return true;
+        }
+        else
+        {
+            logErrorP("Expected format: wifi<Sep><SSID><Sep><PSK> with <Sep> single char not in <SSID>");
+            return false;
+        }
     }
 
     // else if (cmd == "net recon" && strlen(_wifiSSID) > 0)


### PR DESCRIPTION
Alternativvorschlag zu #13 

# Motivation

Über Konsole können keine SSIDs mit Leerzeichen gesetzt werden, da diese als Trennzeichen verwendet zwischen SSID und PSK verwendet werden

# Lösungsvorschlag

Nutzung eines beliebigen einzelnen Trennzeichens. Dieses wird durch das erste Zeichen hinter `wifi` definiert, das bisher immer ein Leerzeichen war. Dadurch ist die Lösung abwärtskompatibel. Angesichts einer Maximallänge der SSID von 32 Zeichen und mehr als 32 auswählbaren Zeichen können auf diesem Wege beliebige SSIDs übergeben werden, die durch die Konsole unterstützt werden.

## Beispiel

Statt einfach nur
```
wifi <SSID> <PSK>
```

das Zeichen direkt nach "wifi" als Trennzeichen hinter der SSID definieren, also z.B.

```
wifiX<SSID>X<PSK>
wifi+<SSID>+<PSK>
```

# Limitationen

Durch diese Erweiterung können keine anderen Kommandos mehr mit dem Präfix `wifi` eingesetzt werden. U.a. wäre die diskutierte Alternativen der Form `wifi0x` oder `wifihex` nicht mehr gleichzeitig nutzbar! Dies muss sorgfältig abgewogen werden.

# Status

Testen erforderlich, bislang nicht erfolgt