### PR TITLE
feat - opt-in fixed ETH link speed (W5500 autoneg-flap workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,23 @@ This module provides the network functionality for the OpenKNX stack.
 
 | Define         | Default  | Description           | Note                                    |
 |----------------|----------|-----------------------|-----------------------------------------|
-| OPENKNX_LED_IP |          | used LED for IP state | set to info2Led to use IP LED feature   |  
+| OPENKNX_LED_IP |          | used LED for IP state | set to info2Led to use IP LED feature   |
+| OPENKNX_ETH_FORCE_SPEED      | (off) | force fixed ETH link speed (10/100)  | ESP32 + KNX_IP_LAN (W5500), autoneg off; opt-in — see "ETH link speed" |
+| OPENKNX_ETH_FORCE_FULLDUPLEX | half  | full-duplex when forcing speed       | optional; only with OPENKNX_ETH_FORCE_SPEED                            |  
+
+## ETH link speed (opt-in, ESP32 + W5500 LAN)
+
+By default the ETH PHY uses auto-negotiation. Two optional build flags force a fixed link
+speed with auto-negotiation off — a workaround for cheap/unmanaged switches that don't hold
+100 Mbit auto-negotiation with the W5500 (link flapping). Not needed on a proper switch.
+Applied before `begin()`; half-duplex is the safe default (an autoneg switch picks HALF via
+parallel detection, so forcing FULL would cause a duplex mismatch). 10 Mbit is plenty for KNX-IP.
+
+```ini
+build_flags =
+  -D OPENKNX_ETH_FORCE_SPEED=10      ; 10 or 100 Mbit; enables the fixed mode (autoneg off)
+  -D OPENKNX_ETH_FORCE_FULLDUPLEX    ; optional; without it = half-duplex
+```
 
 ## IP LED
 

--- a/src/NetworkModule.cpp
+++ b/src/NetworkModule.cpp
@@ -270,6 +270,22 @@ void NetworkModule::initIp()
     else
         KNX_NETIF.begin();
 #else
+    // ETH link mode: auto-negotiation by default. Optional build flags force a FIXED speed (autoneg
+    // OFF) as a workaround for cheap/unmanaged switches that flap on 100M autoneg with the W5500;
+    // not needed on a proper switch. Applied before begin(); half-duplex is the safe default.
+    //   -D OPENKNX_ETH_FORCE_SPEED=10     (10 or 100 Mbit; enables the fixed mode)
+    //   -D OPENKNX_ETH_FORCE_FULLDUPLEX   (optional; default = half-duplex)
+#if defined(KNX_IP_LAN) && defined(OPENKNX_ETH_FORCE_SPEED)
+  #ifdef OPENKNX_ETH_FORCE_FULLDUPLEX
+    const bool _ethForceFull = true;
+  #else
+    const bool _ethForceFull = false;
+  #endif
+    logInfoP("ETH: forcing fixed link %d Mbit %s-duplex (autoneg off)", (int)(OPENKNX_ETH_FORCE_SPEED), _ethForceFull ? "full" : "half");
+    KNX_NETIF.setAutoNegotiation(false);
+    KNX_NETIF.setLinkSpeed(OPENKNX_ETH_FORCE_SPEED);
+    KNX_NETIF.setFullDuplex(_ethForceFull);
+#endif
     KNX_NETIF.begin();
     KNX_NETIF.config(_staticLocalIP, _staticGatewayIP, _staticSubnetMask, _staticNameServerIP); // Stupid: Nedd to be after begin an also DHCP!
 #endif


### PR DESCRIPTION
Add two optional build flags to force a fixed ETH link speed with auto-negotiation disabled, applied before begin():

  -D OPENKNX_ETH_FORCE_SPEED=10       ; 10 or 100 Mbit, enables the fixed mode
  -D OPENKNX_ETH_FORCE_FULLDUPLEX     ; optional, default = half-duplex

For testing/dev Purpose - Workaround for cheap/unmanaged switches that don't hold 100M auto-negotiation with the W5500 (link flapping). Default behaviour is unchanged (auto-negotiation). Document the flags in the README.